### PR TITLE
Aircrafts PK is now an ID instead of tail number

### DIFF
--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -8,11 +8,7 @@ use Carbon\Carbon;
 
 class Aircraft extends Model
 {
-    use HasFactory;
-
-    protected $primaryKey = 'registration';
-    public $incrementing = false;
-    protected $keyType = 'string';
+   use HasFactory;
 
    protected $fillable = [
         'registration',

--- a/database/migrations/2024_03_17_202915_create_aircraft_table.php
+++ b/database/migrations/2024_03_17_202915_create_aircraft_table.php
@@ -14,7 +14,8 @@ class CreateAircraftTable extends Migration
     public function up()
     {
         Schema::create('aircraft', function (Blueprint $table) {
-            $table->string("registration", 6)->primary();
+            $table->id(); # internal id
+            $table->string("registration", 6);
             $table->string("manufacturer", 100);
             $table->string("model", 100);
             $table->string("current_loc", 4);

--- a/database/migrations/2024_03_18_200253_create_flights_table.php
+++ b/database/migrations/2024_03_18_200253_create_flights_table.php
@@ -21,8 +21,8 @@ class CreateFlightsTable extends Migration
             $table->integer('flightnumber');
             $table->string('departure_icao', 4);
             $table->string('arrival_icao', 4);
-            $table->string('aircraft', 6);
-            $table->foreign('aircraft')->references('registration')->on('aircraft');
+            $table->foreignId('aircraft');
+            $table->foreign('aircraft')->references('id')->on('aircraft');
             $table->integer('crzalt');
             $table->datetime('blockoff');
             $table->datetime('blockon');


### PR DESCRIPTION
It is better to make the PK of the aircraft not the tail number, because now multiple airlines can use the same tail number, which was not possible.